### PR TITLE
fix(圓形進度條): 新增 enum 來去選擇大、中、小的進度文字和%數

### DIFF
--- a/src/components/block/card/Card.tsx
+++ b/src/components/block/card/Card.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import Chip from '@mui/material/Chip';
 import CircularDeterminate from '@/components/block/circularDeterminate/CircularDeterminate';
 import Link from 'next/link';
+import { DeterminateSize } from '@/components/types/enum';
 
 interface ImgMediaCardProps {
   projectType: string;
@@ -14,6 +15,7 @@ interface ImgMediaCardProps {
 
 const ImgMediaCard: React.FC<ImgMediaCardProps> = (props) => {
   const { projectType, projectName } = props;
+  const textSize = DeterminateSize.Medium;
 
   return (
     <Card className="md:max-w-card-pc max-w-card-mobile md:p-card-pc p-card-mobile rounded-lg border-secondary shadow-none border border-solid border-opacity-[.12]">
@@ -37,7 +39,7 @@ const ImgMediaCard: React.FC<ImgMediaCardProps> = (props) => {
         </Link>
         <div className="h-px bg-secondary/[.12] my-5"></div>
         <div className="flex items-center gap-5">
-          <CircularDeterminate value={30} size={'4em'} />
+          <CircularDeterminate value={30} size={'4em'} textSize={textSize} />
           <div>
             <div>
               <Typography className="opacity-60 mr-2" component="span" variant="caption" color="secondary">

--- a/src/components/block/circularDeterminate/CircularDeterminate.tsx
+++ b/src/components/block/circularDeterminate/CircularDeterminate.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { DeterminateSize } from '@/components/types/enum';
 
 const StyledCircularProgress = styled(CircularProgress)(({ theme }) => ({
   '& .MuiCircularProgress-circle': {
@@ -11,10 +12,11 @@ const StyledCircularProgress = styled(CircularProgress)(({ theme }) => ({
 interface ICircularDeterminateProps {
   value: number;
   size: string;
+  textSize: DeterminateSize;
 }
 
 const CircularDeterminate: React.FC<ICircularDeterminateProps> = (props) => {
-  const { value, size } = props;
+  const { value, size, textSize } = props;
 
   return (
     <Box className="relative inline-flex">
@@ -26,13 +28,43 @@ const CircularDeterminate: React.FC<ICircularDeterminateProps> = (props) => {
       />
       <StyledCircularProgress variant="determinate" value={value} size={size} className="text-green-accent" />
       <Box className="absolute inset-0 flex items-center justify-center">
-        <Typography variant="body16" component="span" color="primary">
-          {`${Math.round(value)}`}
-          <span className="text-xs pl-px">%</span>
-        </Typography>
+        <TextComponent textSize={textSize} value={value} />
       </Box>
     </Box>
   );
+};
+
+const TextComponent: React.FC<{ textSize: DeterminateSize; value: number }> = ({ textSize, value }) => {
+  switch (textSize) {
+    case DeterminateSize.Large:
+      return (
+        <>
+          <span className=" text-3xl text-primary">{`${Math.round(value)}`}</span>
+          <span className="text-xl pl-px text-primary">%</span>
+        </>
+      );
+    case DeterminateSize.Small:
+      return (
+        <>
+          <span className="text-base text-primary">{`${Math.round(value)}`}</span>
+          <span className="text-xs pl-px text-primary">%</span>
+        </>
+      );
+    case DeterminateSize.Medium:
+      return (
+        <>
+          <span className="text-2xl text-primary">{`${Math.round(value)}`}</span>
+          <span className="text-base pl-px text-primary">%</span>
+        </>
+      );
+    default:
+      return (
+        <>
+          <span className="text-2xl text-primary">{`${Math.round(value)}`}</span>
+          <span className="text-base pl-px text-primary">%</span>
+        </>
+      );
+  }
 };
 
 export default CircularDeterminate;

--- a/src/components/types/enum.ts
+++ b/src/components/types/enum.ts
@@ -1,0 +1,8 @@
+export enum DeterminateSize {
+  /** @description 首頁大輪播的進度 % 數 */
+  Large = 'large',
+  /** @description 2.0 單一專案的進度 % 數 */
+  Medium = 'medium',
+  /** @description 首頁熱門、最新的進度 % 數 */
+  Small = 'small',
+}

--- a/src/pages/mui-layout/index.tsx
+++ b/src/pages/mui-layout/index.tsx
@@ -2,6 +2,8 @@ import { Container, Box, Grid, Stack, Button, IconButton, Typography, Avatar } f
 import { Bolt, Add, Facebook, Instagram, YouTube, Search, Google, EmailOutlined, Public } from '@mui/icons-material';
 import Link from 'next/link';
 import CircularDeterminate from '@/components/block/circularDeterminate';
+import { DeterminateSize } from '@/components/types/enum';
+
 const Mui = () => {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -11,6 +13,10 @@ const Mui = () => {
       password: data.get('password'),
     });
   };
+
+  const determinateSmall = DeterminateSize.Small;
+  const determinateMedium = DeterminateSize.Medium;
+  const determinateLarge = DeterminateSize.Large;
 
   return (
     <Container component="div" maxWidth="xs">
@@ -147,9 +153,9 @@ const Mui = () => {
         </Button>
       </Box>
       <Box className="mb-10">
-        <CircularDeterminate value={42} size={'5em'} />
-        <CircularDeterminate value={66} size={'5em'} />
-        <CircularDeterminate value={80} size={'5em'} />
+        <CircularDeterminate value={42} size={'5em'} textSize={determinateSmall} />
+        <CircularDeterminate value={66} size={'5em'} textSize={determinateMedium} />
+        <CircularDeterminate value={80} size={'5em'} textSize={determinateLarge} />
       </Box>
     </Container>
   );


### PR DESCRIPTION
因為在製作首頁時，會有兩種圓形進度條，目前圓形大小可以調整，但中間的文字不能調整，所以我製作了大、中、小的文字，在 mui-layout 的地方有放 demo。順便練習看看 enum 的使用方法，目前多創了個 types/enum.ts ，未來根據開發的需求和討論再做調整。